### PR TITLE
fix: PATCH -> enterprise extensions are not mangled anymore

### DIFF
--- a/pkg/v2/service/patch.go
+++ b/pkg/v2/service/patch.go
@@ -273,7 +273,7 @@ func makePropertiesAADCompatible(raw json.RawMessage) (json.RawMessage, error) {
 	result := make(map[string]interface{})
 
 	for k, v := range input {
-		if strings.Contains(k, ".") {
+		if strings.Contains(k, ".") && !strings.Contains(k, "extension:enterprise") {
 			parts := strings.SplitN(k, ".", 2)
 			if _, ok := result[parts[0]]; !ok {
 				result[parts[0]] = make(map[string]interface{})

--- a/pkg/v2/service/patch_test.go
+++ b/pkg/v2/service/patch_test.go
@@ -454,4 +454,12 @@ func Test_MakePropertiesAADCompatible(t *testing.T) {
 
 		assert.Equal(t, string(raw), string(res))
 	})
+
+	t.Run("don't mangle enterprise extensions", func(t *testing.T) {
+		raw := json.RawMessage(`{"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User":{"manager":"123456"}}`)
+		res, err := makePropertiesAADCompatible(raw)
+		assert.NoError(t, err)
+
+		assert.Equal(t, string(raw), string(res))
+	})
 }

--- a/public/schemas/user_enterprise_extension_schema.json
+++ b/public/schemas/user_enterprise_extension_schema.json
@@ -41,35 +41,9 @@
     {
       "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager",
       "name": "manager",
-      "type": "complex",
+      "type": "string",
       "_index": 5,
-      "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager",
-      "_annotations": {
-        "@StateSummary": {}
-      },
-      "subAttributes": [
-        {
-          "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.value",
-          "name": "value",
-          "type": "string",
-          "_index": 0,
-          "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.value"
-        },
-        {
-          "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.$ref",
-          "name": "$ref",
-          "type": "reference",
-          "_index": 1,
-          "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.$ref"
-        },
-        {
-          "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.displayName",
-          "name": "displayName",
-          "type": "string",
-          "_index": 2,
-          "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.displayName"
-        }
-      ]
+      "_path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager"
     }
   ]
 }


### PR DESCRIPTION
This fixes an issue with SCIM PATCH operations that contain enterprise extensions (Azure AD). Previously, those patches would never be applied. This is now fixed.